### PR TITLE
Build type finder for agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ The tool is located in the `src/TypeFinder` directory. To use it, you need .NET 
 Use the provided installation script to publish and install the tool:
 
 ```bash
-./find-type.sh --install-dir ~/.local/bin
+./install-typefinder.sh --install-dir ~/.local/bin
 ```
 
 This will:

--- a/README.md
+++ b/README.md
@@ -16,6 +16,21 @@ This tool is specifically designed for integration with coding agents like Curso
 
 The tool is located in the `src/TypeFinder` directory. To use it, you need .NET 8.0 or later installed.
 
+### Quick Installation
+
+Use the provided installation script to publish and install the tool:
+
+```bash
+./find-type.sh --install-dir ~/.local/bin
+```
+
+This will:
+1. Publish the TypeFinder tool (using Native AOT if dependencies are available)
+2. Create a symlink named `find-type` in the specified directory
+3. Make the tool available for use
+
+**Note**: Native AOT publishing is preferred for better performance, however, it should only be used if the following two packages are installed: `clang`, `zlib1g-dev`.
+
 ### Installing .NET (if not already installed)
 
 ```bash
@@ -27,9 +42,9 @@ export PATH="$HOME/.dotnet:$PATH"
 
 ### Basic Usage
 
-#### Using the wrapper script (recommended for agents):
+#### Using the installed tool (recommended):
 ```bash
-./find-type.sh <type-name> [options]
+find-type <workspace-path> <type-name> [options]
 ```
 
 #### Using the .NET application directly:
@@ -42,37 +57,37 @@ dotnet run -- <workspace-path> <type-name>
 
 1. **Find a class named "User" in the workspace:**
    ```bash
-   ./find-type.sh User
+   find-type . User
    ```
 
 2. **Find exact type definitions only:**
    ```bash
-   ./find-type.sh "MyClass" --exact-match
+   find-type . "MyClass" --exact-match
    ```
 
 3. **Search only in C# and TypeScript files:**
    ```bash
-   ./find-type.sh Controller --file-types .cs,.ts
+   find-type . Controller --file-types .cs,.ts
    ```
 
 4. **Case-sensitive search:**
    ```bash
-   ./find-type.sh "MyClass" --case-sensitive
+   find-type . "MyClass" --case-sensitive
    ```
 
 5. **Limit results to 10:**
    ```bash
-   ./find-type.sh Service --max-results 10
+   find-type . Service --max-results 10
    ```
 
 6. **Search in a specific workspace:**
    ```bash
-   ./find-type.sh User --workspace /path/to/other/workspace
+   find-type /path/to/other/workspace User
    ```
 
 7. **Find all references to a type:**
    ```bash
-   ./find-type.sh MyClass --include-references
+   find-type . MyClass --include-references
    ```
 
 ## Command Line Options
@@ -84,7 +99,6 @@ dotnet run -- <workspace-path> <type-name>
 | `--file-types` | Comma-separated list of file extensions to search | `.cs,.ts,.js,.py,.java,.go,.rs,.php` |
 | `--max-results` | Maximum number of results to return | 50 |
 | `--include-references` | Include type references (not just definitions) | false |
-| `--workspace` | Specify workspace path (wrapper script only) | current directory |
 
 ## Supported File Types
 
@@ -137,16 +151,16 @@ Coding agents can use this tool to:
 
 ```bash
 # Agent wants to find the User class definition
-./find-type.sh User --exact-match
+find-type . User --exact-match
 
 # Agent wants to see all usages of a specific interface
-./find-type.sh IUserService --include-references
+find-type . IUserService --include-references
 
 # Agent wants to find all controller classes
-./find-type.sh Controller --file-types .cs,.ts
+find-type . Controller --file-types .cs,.ts
 
 # Agent wants to understand all references to a type
-./find-type.sh MyClass --include-references --max-results 100
+find-type . MyClass --include-references --max-results 100
 ```
 
 ## Building and Running
@@ -163,8 +177,17 @@ dotnet run -- <arguments>
 ```
 
 ### Create a Standalone Executable
+
+To publish an app in the default mode, use `dotnet publish`. That produces a release binary for the current machine:
+
 ```bash
 dotnet publish -c Release -r linux-x64 --self-contained true
+```
+
+For Native AOT (requires clang and zlib1g-dev), use:
+
+```bash
+dotnet publish -c Release -r linux-x64 --self-contained true -p:PublishAot=true
 ```
 
 ## Features

--- a/README.md
+++ b/README.md
@@ -1,14 +1,16 @@
-# TypeFinder - Type Location Tool for Coding Agents
+# TypeFinder - Advanced Type Location Tool for Coding Agents
 
-TypeFinder is a .NET console application designed to help coding agents quickly locate types within a workspace. It provides fast, accurate type discovery across multiple programming languages and file types.
+TypeFinder is a .NET console application designed to help coding agents quickly locate types within a workspace. It leverages the Roslyn compiler APIs to provide fast, accurate, and comprehensive type discovery across multiple programming languages and file types.
 
 ## Overview
 
 This tool is specifically designed for integration with coding agents like Cursor, providing them with the ability to:
-- Find exact locations of type definitions
-- Search across multiple programming languages
-- Get contextual information about type usage
+- Find exact locations of type definitions using Roslyn compiler APIs
+- Discover all references to types throughout the codebase
+- Search across multiple programming languages with fallback to file-based search
+- Get contextual information about type usage with precise line numbers
 - Filter results by file types and search criteria
+- Understand type relationships and dependencies
 
 ## Installation
 
@@ -68,6 +70,11 @@ dotnet run -- <workspace-path> <type-name>
    ./find-type.sh User --workspace /path/to/other/workspace
    ```
 
+7. **Find all references to a type:**
+   ```bash
+   ./find-type.sh MyClass --include-references
+   ```
+
 ## Command Line Options
 
 | Option | Description | Default |
@@ -76,6 +83,7 @@ dotnet run -- <workspace-path> <type-name>
 | `--case-sensitive` | Use case-sensitive search | false |
 | `--file-types` | Comma-separated list of file extensions to search | `.cs,.ts,.js,.py,.java,.go,.rs,.php` |
 | `--max-results` | Maximum number of results to return | 50 |
+| `--include-references` | Include type references (not just definitions) | false |
 | `--workspace` | Specify workspace path (wrapper script only) | current directory |
 
 ## Supported File Types
@@ -99,17 +107,19 @@ The tool provides structured output with the following information for each matc
 ```
 File: /path/to/file.cs
 Line: 42
+Type: MyClass
+Kind: class
 Context:     public class MyClass
 >>>         {
 >>>             private string _name;
 >>>         }
-Type: class
 ```
 
 - **File**: Full path to the file containing the type
 - **Line**: Line number where the type was found
+- **Type**: The actual type name that was found
+- **Kind**: Type of the match (class, interface, struct, enum, record, namespace, method, property, field, event, reference, or symbol)
 - **Context**: Surrounding code context (2 lines before and after)
-- **Type**: Type of the match (class, interface, struct, enum, record, type, typedef, function, or reference)
 
 ## Integration with Coding Agents
 
@@ -118,9 +128,10 @@ Type: class
 Coding agents can use this tool to:
 
 1. **Locate type definitions** when they need to understand the structure of a type
-2. **Find usage patterns** to understand how types are used throughout the codebase
+2. **Find all references** to understand how types are used throughout the codebase
 3. **Get contextual information** to make better code suggestions
 4. **Discover related types** by searching for similar naming patterns
+5. **Understand type relationships** by analyzing dependencies and usage patterns
 
 ### Example Agent Usage
 
@@ -129,10 +140,13 @@ Coding agents can use this tool to:
 ./find-type.sh User --exact-match
 
 # Agent wants to see all usages of a specific interface
-./find-type.sh IUserService
+./find-type.sh IUserService --include-references
 
 # Agent wants to find all controller classes
 ./find-type.sh Controller --file-types .cs,.ts
+
+# Agent wants to understand all references to a type
+./find-type.sh MyClass --include-references --max-results 100
 ```
 
 ## Building and Running
@@ -155,11 +169,13 @@ dotnet publish -c Release -r linux-x64 --self-contained true
 
 ## Features
 
-- **Multi-language Support**: Searches across multiple programming languages
-- **Flexible Search**: Exact match or partial match options
+- **Roslyn Integration**: Uses Microsoft's Roslyn compiler APIs for accurate type analysis
+- **Multi-language Support**: Searches across multiple programming languages with fallback to file-based search
+- **Comprehensive Discovery**: Finds both type definitions and all references throughout the codebase
+- **Flexible Search**: Exact match or partial match options with case sensitivity control
 - **Contextual Output**: Shows surrounding code for better understanding
-- **Performance Optimized**: Fast recursive file searching
-- **Error Handling**: Graceful handling of permission errors and invalid files
+- **Performance Optimized**: Fast compilation-based searching with configurable limits
+- **Error Handling**: Graceful handling of compilation errors and invalid files
 - **Configurable**: Customizable file types and result limits
 
 ## Error Handling
@@ -168,13 +184,15 @@ The tool handles various error conditions gracefully:
 - Invalid workspace paths
 - Permission denied errors when accessing files
 - Unreadable or corrupted files
+- Compilation errors in projects
 - Invalid command line arguments
 
 ## Performance Considerations
 
-- The tool searches files recursively, so large workspaces may take longer
+- The tool uses Roslyn compilation for accurate analysis, which may take longer for large projects
 - Use `--file-types` to limit search scope for better performance
 - Use `--max-results` to limit output size
+- The tool falls back to file-based search if compilation fails
 - The tool skips files it cannot read and continues with the search
 
 ## Contributing

--- a/README.md
+++ b/README.md
@@ -1,1 +1,186 @@
-# dotnet-find-type
+# TypeFinder - Type Location Tool for Coding Agents
+
+TypeFinder is a .NET console application designed to help coding agents quickly locate types within a workspace. It provides fast, accurate type discovery across multiple programming languages and file types.
+
+## Overview
+
+This tool is specifically designed for integration with coding agents like Cursor, providing them with the ability to:
+- Find exact locations of type definitions
+- Search across multiple programming languages
+- Get contextual information about type usage
+- Filter results by file types and search criteria
+
+## Installation
+
+The tool is located in the `src/TypeFinder` directory. To use it, you need .NET 8.0 or later installed.
+
+### Installing .NET (if not already installed)
+
+```bash
+curl -sSL https://dot.net/v1/dotnet-install.sh | bash /dev/stdin --channel LTS
+export PATH="$HOME/.dotnet:$PATH"
+```
+
+## Usage
+
+### Basic Usage
+
+#### Using the wrapper script (recommended for agents):
+```bash
+./find-type.sh <type-name> [options]
+```
+
+#### Using the .NET application directly:
+```bash
+cd src/TypeFinder
+dotnet run -- <workspace-path> <type-name>
+```
+
+### Examples
+
+1. **Find a class named "User" in the workspace:**
+   ```bash
+   ./find-type.sh User
+   ```
+
+2. **Find exact type definitions only:**
+   ```bash
+   ./find-type.sh "MyClass" --exact-match
+   ```
+
+3. **Search only in C# and TypeScript files:**
+   ```bash
+   ./find-type.sh Controller --file-types .cs,.ts
+   ```
+
+4. **Case-sensitive search:**
+   ```bash
+   ./find-type.sh "MyClass" --case-sensitive
+   ```
+
+5. **Limit results to 10:**
+   ```bash
+   ./find-type.sh Service --max-results 10
+   ```
+
+6. **Search in a specific workspace:**
+   ```bash
+   ./find-type.sh User --workspace /path/to/other/workspace
+   ```
+
+## Command Line Options
+
+| Option | Description | Default |
+|--------|-------------|---------|
+| `--exact-match` | Search for exact type name match (definitions only) | false |
+| `--case-sensitive` | Use case-sensitive search | false |
+| `--file-types` | Comma-separated list of file extensions to search | `.cs,.ts,.js,.py,.java,.go,.rs,.php` |
+| `--max-results` | Maximum number of results to return | 50 |
+| `--workspace` | Specify workspace path (wrapper script only) | current directory |
+
+## Supported File Types
+
+By default, TypeFinder searches in the following file types:
+- `.cs` - C# files
+- `.ts` - TypeScript files
+- `.js` - JavaScript files
+- `.py` - Python files
+- `.java` - Java files
+- `.go` - Go files
+- `.rs` - Rust files
+- `.php` - PHP files
+
+You can customize this list using the `--file-types` option.
+
+## Output Format
+
+The tool provides structured output with the following information for each match:
+
+```
+File: /path/to/file.cs
+Line: 42
+Context:     public class MyClass
+>>>         {
+>>>             private string _name;
+>>>         }
+Type: class
+```
+
+- **File**: Full path to the file containing the type
+- **Line**: Line number where the type was found
+- **Context**: Surrounding code context (2 lines before and after)
+- **Type**: Type of the match (class, interface, struct, enum, record, type, typedef, function, or reference)
+
+## Integration with Coding Agents
+
+### For Cursor and Similar Agents
+
+Coding agents can use this tool to:
+
+1. **Locate type definitions** when they need to understand the structure of a type
+2. **Find usage patterns** to understand how types are used throughout the codebase
+3. **Get contextual information** to make better code suggestions
+4. **Discover related types** by searching for similar naming patterns
+
+### Example Agent Usage
+
+```bash
+# Agent wants to find the User class definition
+./find-type.sh User --exact-match
+
+# Agent wants to see all usages of a specific interface
+./find-type.sh IUserService
+
+# Agent wants to find all controller classes
+./find-type.sh Controller --file-types .cs,.ts
+```
+
+## Building and Running
+
+### Build the Application
+```bash
+cd src/TypeFinder
+dotnet build
+```
+
+### Run the Application
+```bash
+dotnet run -- <arguments>
+```
+
+### Create a Standalone Executable
+```bash
+dotnet publish -c Release -r linux-x64 --self-contained true
+```
+
+## Features
+
+- **Multi-language Support**: Searches across multiple programming languages
+- **Flexible Search**: Exact match or partial match options
+- **Contextual Output**: Shows surrounding code for better understanding
+- **Performance Optimized**: Fast recursive file searching
+- **Error Handling**: Graceful handling of permission errors and invalid files
+- **Configurable**: Customizable file types and result limits
+
+## Error Handling
+
+The tool handles various error conditions gracefully:
+- Invalid workspace paths
+- Permission denied errors when accessing files
+- Unreadable or corrupted files
+- Invalid command line arguments
+
+## Performance Considerations
+
+- The tool searches files recursively, so large workspaces may take longer
+- Use `--file-types` to limit search scope for better performance
+- Use `--max-results` to limit output size
+- The tool skips files it cannot read and continues with the search
+
+## Contributing
+
+This tool is designed to be simple and focused. If you need additional features, consider:
+- Adding support for more file types
+- Implementing more sophisticated type detection patterns
+- Adding support for different output formats (JSON, XML, etc.)
+- Implementing caching for large workspaces

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ This will:
 2. Create a symlink named `find-type` in the specified directory
 3. Make the tool available for use
 
-**Note**: Native AOT publishing is preferred for better performance, however, it should only be used if the following two packages are installed: `clang`, `zlib1g-dev`.
+
 
 ### Installing .NET (if not already installed)
 
@@ -184,11 +184,7 @@ To publish an app in the default mode, use `dotnet publish`. That produces a rel
 dotnet publish -c Release -r linux-x64 --self-contained true
 ```
 
-For Native AOT (requires clang and zlib1g-dev), use:
 
-```bash
-dotnet publish -c Release -r linux-x64 --self-contained true -p:PublishAot=true
-```
 
 ## Features
 

--- a/find-type.sh
+++ b/find-type.sh
@@ -1,0 +1,56 @@
+#!/bin/bash
+
+# TypeFinder wrapper script for easier usage by coding agents
+# Usage: ./find-type.sh <type-name> [options]
+
+if [ $# -eq 0 ] || [ "$1" = "--help" ] || [ "$1" = "-h" ]; then
+    echo "Usage: ./find-type.sh <type-name> [options]"
+    echo ""
+    echo "Options:"
+    echo "  --exact-match    Search for exact type name match"
+    echo "  --case-sensitive Use case-sensitive search"
+    echo "  --file-types     Comma-separated list of file extensions to search"
+    echo "  --max-results    Maximum number of results to return"
+    echo "  --workspace      Specify workspace path (default: current directory)"
+    echo "  --help, -h       Show this help message"
+    echo ""
+    echo "Examples:"
+    echo "  ./find-type.sh User"
+    echo "  ./find-type.sh \"MyClass\" --exact-match"
+    echo "  ./find-type.sh Controller --file-types .cs,.ts"
+    exit 1
+fi
+
+# Default workspace to current directory
+WORKSPACE_PATH="."
+TYPE_NAME="$1"
+shift
+
+# Parse options
+OPTIONS=""
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        --workspace)
+            WORKSPACE_PATH="$2"
+            shift 2
+            ;;
+        *)
+            OPTIONS="$OPTIONS $1"
+            shift
+            ;;
+    esac
+done
+
+# Ensure .NET is available
+if ! command -v dotnet &> /dev/null; then
+    if [ -d "$HOME/.dotnet" ]; then
+        export PATH="$HOME/.dotnet:$PATH"
+    else
+        echo "Error: .NET is not installed. Please install .NET 8.0 or later."
+        exit 1
+    fi
+fi
+
+# Run the TypeFinder
+cd "$(dirname "$0")/src/TypeFinder"
+dotnet run -- "$WORKSPACE_PATH" "$TYPE_NAME" $OPTIONS

--- a/find-type.sh
+++ b/find-type.sh
@@ -11,6 +11,7 @@ if [ $# -eq 0 ] || [ "$1" = "--help" ] || [ "$1" = "-h" ]; then
     echo "  --case-sensitive Use case-sensitive search"
     echo "  --file-types     Comma-separated list of file extensions to search"
     echo "  --max-results    Maximum number of results to return"
+    echo "  --include-references Include type references (not just definitions)"
     echo "  --workspace      Specify workspace path (default: current directory)"
     echo "  --help, -h       Show this help message"
     echo ""
@@ -18,6 +19,7 @@ if [ $# -eq 0 ] || [ "$1" = "--help" ] || [ "$1" = "-h" ]; then
     echo "  ./find-type.sh User"
     echo "  ./find-type.sh \"MyClass\" --exact-match"
     echo "  ./find-type.sh Controller --file-types .cs,.ts"
+    echo "  ./find-type.sh MyClass --include-references"
     exit 1
 fi
 

--- a/install-typefinder.sh
+++ b/install-typefinder.sh
@@ -59,30 +59,12 @@ fi
 # Create installation directory if it doesn't exist
 mkdir -p "$INSTALL_DIR"
 
-# Check if we should use Native AOT
-USE_AOT=false
-if command -v clang &> /dev/null && dpkg -l | grep -q zlib1g-dev; then
-    echo "Native AOT dependencies found (clang, zlib1g-dev). Using Native AOT publishing."
-    USE_AOT=true
-else
-    echo "Native AOT dependencies not found. Using standard publishing."
-    echo "To enable Native AOT, install: clang, zlib1g-dev"
-fi
-
 # Publish the application
 echo "Publishing TypeFinder..."
 
 cd "$PROJECT_DIR"
-
-if [ "$USE_AOT" = true ]; then
-    echo "Publishing with Native AOT..."
-    dotnet publish -c Release -r linux-x64 --self-contained true -p:PublishAot=true
-    PUBLISH_DIR="../../artifacts/publish/TypeFinder/release_linux-x64"
-else
-    echo "Publishing with standard compilation..."
-    dotnet publish -c Release -r linux-x64 --self-contained true
-    PUBLISH_DIR="../../artifacts/publish/TypeFinder/release_linux-x64"
-fi
+dotnet publish -c Release -r linux-x64 --self-contained true
+PUBLISH_DIR="../../artifacts/publish/TypeFinder/release_linux-x64"
 
 # Find the executable
 EXECUTABLE=""

--- a/install-typefinder.sh
+++ b/install-typefinder.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# TypeFinder installation and symlink script
+# TypeFinder Installation Script
 # This script publishes the TypeFinder tool and creates a symlink for easy access
 
 set -e

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -1,6 +1,5 @@
 <Project>
   <PropertyGroup>
-    <IsAotCompatible>true</IsAotCompatible>
     <UseArtifactsOutput>true</UseArtifactsOutput>
     <ArtifactsPath>$(MSBuildThisFileDirectory)../artifacts</ArtifactsPath>
   </PropertyGroup>

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -1,0 +1,7 @@
+<Project>
+  <PropertyGroup>
+    <IsAotCompatible>true</IsAotCompatible>
+    <UseArtifactsOutput>true</UseArtifactsOutput>
+    <ArtifactsPath>$(MSBuildThisFileDirectory)../artifacts</ArtifactsPath>
+  </PropertyGroup>
+</Project>

--- a/src/TypeFinder/Program.cs
+++ b/src/TypeFinder/Program.cs
@@ -1,14 +1,19 @@
 using System;
 using System.IO;
-using System.Text.RegularExpressions;
-using System.Collections.Generic;
 using System.Linq;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using System.Text.RegularExpressions;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.MSBuild;
+using Microsoft.CodeAnalysis.FindSymbols;
+using Microsoft.CodeAnalysis.Text;
 
 namespace TypeFinder
 {
     class Program
     {
-        static void Main(string[] args)
+        static async Task<int> Main(string[] args)
         {
             if (args.Length < 2)
             {
@@ -19,12 +24,13 @@ namespace TypeFinder
                 Console.WriteLine("  --case-sensitive Use case-sensitive search");
                 Console.WriteLine("  --file-types     Comma-separated list of file extensions to search (default: .cs,.ts,.js,.py,.java,.go,.rs,.php)");
                 Console.WriteLine("  --max-results    Maximum number of results to return (default: 50)");
+                Console.WriteLine("  --include-references Include type references (not just definitions)");
                 Console.WriteLine();
                 Console.WriteLine("Examples:");
                 Console.WriteLine("  TypeFinder /path/to/workspace User");
                 Console.WriteLine("  TypeFinder /path/to/workspace \"MyClass\" --exact-match");
                 Console.WriteLine("  TypeFinder /path/to/workspace Controller --file-types .cs,.ts");
-                return;
+                return 1;
             }
 
             string workspacePath = args[0];
@@ -36,17 +42,17 @@ namespace TypeFinder
             if (!Directory.Exists(workspacePath))
             {
                 Console.WriteLine($"Error: Workspace path '{workspacePath}' does not exist.");
-                Environment.Exit(1);
+                return 1;
             }
 
             try
             {
-                var results = FindType(workspacePath, typeName, options);
+                var results = await FindTypeAsync(workspacePath, typeName, options);
                 
                 if (results.Count == 0)
                 {
                     Console.WriteLine($"No types found matching '{typeName}' in workspace '{workspacePath}'");
-                    return;
+                    return 0;
                 }
 
                 Console.WriteLine($"Found {results.Count} result(s) for type '{typeName}':");
@@ -56,8 +62,9 @@ namespace TypeFinder
                 {
                     Console.WriteLine($"File: {result.FilePath}");
                     Console.WriteLine($"Line: {result.LineNumber}");
-                    Console.WriteLine($"Context: {result.Context}");
                     Console.WriteLine($"Type: {result.Type}");
+                    Console.WriteLine($"Kind: {result.Kind}");
+                    Console.WriteLine($"Context: {result.Context}");
                     Console.WriteLine();
                 }
 
@@ -65,11 +72,13 @@ namespace TypeFinder
                 {
                     Console.WriteLine($"... and {results.Count - options.MaxResults} more results (use --max-results to see more)");
                 }
+
+                return 0;
             }
             catch (Exception ex)
             {
                 Console.WriteLine($"Error: {ex.Message}");
-                Environment.Exit(1);
+                return 1;
             }
         }
 
@@ -99,13 +108,260 @@ namespace TypeFinder
                             options.MaxResults = maxResults;
                         }
                         break;
+                    case "--include-references":
+                        options.IncludeReferences = true;
+                        break;
                 }
             }
 
             return options;
         }
 
-        static List<TypeResult> FindType(string workspacePath, string typeName, SearchOptions options)
+        static async Task<List<TypeResult>> FindTypeAsync(string workspacePath, string typeName, SearchOptions options)
+        {
+            var results = new List<TypeResult>();
+
+            // Try to find solution files first
+            var solutionFiles = Directory.GetFiles(workspacePath, "*.sln", SearchOption.AllDirectories);
+            
+            if (solutionFiles.Length > 0)
+            {
+                foreach (var solutionFile in solutionFiles)
+                {
+                    try
+                    {
+                        var solutionResults = await SearchSolutionAsync(solutionFile, typeName, options);
+                        results.AddRange(solutionResults);
+                    }
+                    catch (Exception ex)
+                    {
+                        Console.WriteLine($"Warning: Could not process solution {solutionFile}: {ex.Message}");
+                    }
+                }
+            }
+
+            // If no solution files or no results, try project files
+            if (results.Count == 0)
+            {
+                var projectFiles = Directory.GetFiles(workspacePath, "*.csproj", SearchOption.AllDirectories);
+                
+                foreach (var projectFile in projectFiles)
+                {
+                    try
+                    {
+                        var projectResults = await SearchProjectAsync(projectFile, typeName, options);
+                        results.AddRange(projectResults);
+                    }
+                    catch (Exception ex)
+                    {
+                        Console.WriteLine($"Warning: Could not process project {projectFile}: {ex.Message}");
+                    }
+                }
+            }
+
+            // If still no results, fall back to file-based search
+            if (results.Count == 0)
+            {
+                var fileResults = await SearchFilesAsync(workspacePath, typeName, options);
+                results.AddRange(fileResults);
+            }
+
+            return results;
+        }
+
+        static async Task<List<TypeResult>> SearchSolutionAsync(string solutionPath, string typeName, SearchOptions options)
+        {
+            var results = new List<TypeResult>();
+            
+            using var workspace = MSBuildWorkspace.Create();
+            var solution = await workspace.OpenSolutionAsync(solutionPath);
+
+            foreach (var project in solution.Projects)
+            {
+                try
+                {
+                    var projectResults = await SearchProjectSymbolsAsync(project, typeName, options);
+                    results.AddRange(projectResults);
+                }
+                catch (Exception ex)
+                {
+                    Console.WriteLine($"Warning: Could not process project {project.Name}: {ex.Message}");
+                }
+            }
+
+            return results;
+        }
+
+        static async Task<List<TypeResult>> SearchProjectAsync(string projectPath, string typeName, SearchOptions options)
+        {
+            using var workspace = MSBuildWorkspace.Create();
+            var project = await workspace.OpenProjectAsync(projectPath);
+            return await SearchProjectSymbolsAsync(project, typeName, options);
+        }
+
+        static async Task<List<TypeResult>> SearchProjectSymbolsAsync(Project project, string typeName, SearchOptions options)
+        {
+            var results = new List<TypeResult>();
+            var compilation = await project.GetCompilationAsync();
+            
+            if (compilation == null) return results;
+
+            // Search for type symbols
+            var symbols = new List<ISymbol>();
+
+            // Search in global namespace
+            var globalNamespace = compilation.GlobalNamespace;
+            symbols.AddRange(FindSymbolsInNamespace(globalNamespace, typeName, options));
+
+            // Search in all namespaces
+            foreach (var namespaceSymbol in GetAllNamespaces(globalNamespace))
+            {
+                symbols.AddRange(FindSymbolsInNamespace(namespaceSymbol, typeName, options));
+            }
+
+            foreach (var symbol in symbols)
+            {
+                var locations = symbol.Locations;
+                foreach (var location in locations)
+                {
+                    if (location.IsInSource)
+                    {
+                        var result = await CreateTypeResultAsync(location, symbol, project, options);
+                        if (result != null)
+                        {
+                            results.Add(result);
+                        }
+                    }
+                }
+
+                // If including references, also find all references to this symbol
+                if (options.IncludeReferences)
+                {
+                    var references = await SymbolFinder.FindReferencesAsync(symbol, project.Solution);
+                    foreach (var reference in references)
+                    {
+                        foreach (var location in reference.Locations)
+                        {
+                            var result = await CreateTypeResultAsync(location.Location, symbol, project, options);
+                            if (result != null)
+                            {
+                                result.Kind = "reference";
+                                results.Add(result);
+                            }
+                        }
+                    }
+                }
+            }
+
+            return results;
+        }
+
+        static IEnumerable<ISymbol> FindSymbolsInNamespace(INamespaceSymbol namespaceSymbol, string typeName, SearchOptions options)
+        {
+            var symbols = new List<ISymbol>();
+
+            // Search for types in this namespace
+            foreach (var type in namespaceSymbol.GetTypeMembers())
+            {
+                if (MatchesTypeName(type.Name, typeName, options))
+                {
+                    symbols.Add(type);
+                }
+            }
+
+            // Search in nested namespaces
+            foreach (var nestedNamespace in namespaceSymbol.GetNamespaceMembers())
+            {
+                symbols.AddRange(FindSymbolsInNamespace(nestedNamespace, typeName, options));
+            }
+
+            return symbols;
+        }
+
+        static IEnumerable<INamespaceSymbol> GetAllNamespaces(INamespaceSymbol namespaceSymbol)
+        {
+            var namespaces = new List<INamespaceSymbol>();
+            
+            foreach (var member in namespaceSymbol.GetMembers())
+            {
+                if (member is INamespaceSymbol nestedNamespace)
+                {
+                    namespaces.Add(nestedNamespace);
+                    namespaces.AddRange(GetAllNamespaces(nestedNamespace));
+                }
+            }
+
+            return namespaces;
+        }
+
+        static bool MatchesTypeName(string symbolName, string searchName, SearchOptions options)
+        {
+            if (options.ExactMatch)
+            {
+                return options.CaseSensitive 
+                    ? symbolName == searchName 
+                    : string.Equals(symbolName, searchName, StringComparison.OrdinalIgnoreCase);
+            }
+            else
+            {
+                return options.CaseSensitive 
+                    ? symbolName.Contains(searchName) 
+                    : symbolName.IndexOf(searchName, StringComparison.OrdinalIgnoreCase) >= 0;
+            }
+        }
+
+        static async Task<TypeResult?> CreateTypeResultAsync(Location location, ISymbol symbol, Project project, SearchOptions options)
+        {
+            if (!location.IsInSource) return null;
+
+            var sourceText = await location.SourceTree!.GetTextAsync();
+            var lineSpan = sourceText.Lines.GetLinePositionSpan(location.SourceSpan);
+            
+            var context = GetContext(sourceText, lineSpan.Start.Line, options);
+            var typeKind = GetTypeKind(symbol);
+
+            return new TypeResult
+            {
+                FilePath = location.SourceTree!.FilePath,
+                LineNumber = lineSpan.Start.Line + 1,
+                Type = symbol.Name,
+                Kind = typeKind,
+                Context = context
+            };
+        }
+
+        static string GetContext(SourceText sourceText, int lineNumber, SearchOptions options)
+        {
+            var lines = sourceText.Lines;
+            var start = Math.Max(0, lineNumber - 2);
+            var end = Math.Min(lines.Count - 1, lineNumber + 2);
+            
+            var contextLines = new List<string>();
+            for (int i = start; i <= end; i++)
+            {
+                var line = lines[i].ToString();
+                var prefix = i == lineNumber ? ">>> " : "    ";
+                contextLines.Add($"{prefix}{line}");
+            }
+            
+            return string.Join(Environment.NewLine, contextLines);
+        }
+
+        static string GetTypeKind(ISymbol symbol)
+        {
+            return symbol switch
+            {
+                ITypeSymbol typeSymbol => typeSymbol.TypeKind.ToString().ToLower(),
+                INamespaceSymbol => "namespace",
+                IMethodSymbol => "method",
+                IPropertySymbol => "property",
+                IFieldSymbol => "field",
+                IEventSymbol => "event",
+                _ => "symbol"
+            };
+        }
+
+        static async Task<List<TypeResult>> SearchFilesAsync(string workspacePath, string typeName, SearchOptions options)
         {
             var results = new List<TypeResult>();
             var fileExtensions = options.FileTypes ?? new[] { ".cs", ".ts", ".js", ".py", ".java", ".go", ".rs", ".php" };
@@ -114,7 +370,7 @@ namespace TypeFinder
             {
                 try
                 {
-                    var fileResults = SearchFile(file, typeName, options);
+                    var fileResults = await SearchFileAsync(file, typeName, options);
                     results.AddRange(fileResults);
                 }
                 catch (Exception ex)
@@ -139,10 +395,10 @@ namespace TypeFinder
             }
         }
 
-        static List<TypeResult> SearchFile(string filePath, string typeName, SearchOptions options)
+        static async Task<List<TypeResult>> SearchFileAsync(string filePath, string typeName, SearchOptions options)
         {
             var results = new List<TypeResult>();
-            var lines = File.ReadAllLines(filePath);
+            var lines = await File.ReadAllLinesAsync(filePath);
             var comparison = options.CaseSensitive ? StringComparison.Ordinal : StringComparison.OrdinalIgnoreCase;
 
             for (int i = 0; i < lines.Length; i++)
@@ -152,7 +408,6 @@ namespace TypeFinder
 
                 if (options.ExactMatch)
                 {
-                    // Look for exact type definitions
                     if (IsTypeDefinition(line, typeName, comparison))
                     {
                         results.Add(new TypeResult
@@ -160,13 +415,13 @@ namespace TypeFinder
                             FilePath = filePath,
                             LineNumber = lineNumber,
                             Context = GetContext(lines, i),
-                            Type = DetermineTypeFromLine(line)
+                            Type = typeName,
+                            Kind = DetermineTypeFromLine(line)
                         });
                     }
                 }
                 else
                 {
-                    // Look for type name mentions
                     if (line.IndexOf(typeName, comparison) >= 0)
                     {
                         results.Add(new TypeResult
@@ -174,7 +429,8 @@ namespace TypeFinder
                             FilePath = filePath,
                             LineNumber = lineNumber,
                             Context = GetContext(lines, i),
-                            Type = DetermineTypeFromLine(line)
+                            Type = typeName,
+                            Kind = DetermineTypeFromLine(line)
                         });
                     }
                 }
@@ -185,7 +441,6 @@ namespace TypeFinder
 
         static bool IsTypeDefinition(string line, string typeName, StringComparison comparison)
         {
-            // Common patterns for type definitions
             var patterns = new[]
             {
                 $@"\b(class|interface|struct|enum|record)\s+{Regex.Escape(typeName)}\b",
@@ -236,13 +491,15 @@ namespace TypeFinder
         public bool CaseSensitive { get; set; } = false;
         public string[]? FileTypes { get; set; } = null;
         public int MaxResults { get; set; } = 50;
+        public bool IncludeReferences { get; set; } = false;
     }
 
     class TypeResult
     {
         public string FilePath { get; set; } = "";
         public int LineNumber { get; set; }
-        public string Context { get; set; } = "";
         public string Type { get; set; } = "";
+        public string Kind { get; set; } = "";
+        public string Context { get; set; } = "";
     }
 }

--- a/src/TypeFinder/Program.cs
+++ b/src/TypeFinder/Program.cs
@@ -9,497 +9,488 @@ using Microsoft.CodeAnalysis.MSBuild;
 using Microsoft.CodeAnalysis.FindSymbols;
 using Microsoft.CodeAnalysis.Text;
 
-namespace TypeFinder
+if (args.Length < 2)
 {
-    class Program
+    Console.WriteLine("Usage: TypeFinder <workspace-path> <type-name> [options]");
+    Console.WriteLine();
+    Console.WriteLine("Options:");
+    Console.WriteLine("  --exact-match    Search for exact type name match");
+    Console.WriteLine("  --case-sensitive Use case-sensitive search");
+    Console.WriteLine("  --file-types     Comma-separated list of file extensions to search (default: .cs,.ts,.js,.py,.java,.go,.rs,.php)");
+    Console.WriteLine("  --max-results    Maximum number of results to return (default: 50)");
+    Console.WriteLine("  --include-references Include type references (not just definitions)");
+    Console.WriteLine();
+    Console.WriteLine("Examples:");
+    Console.WriteLine("  TypeFinder /path/to/workspace User");
+    Console.WriteLine("  TypeFinder /path/to/workspace \"MyClass\" --exact-match");
+    Console.WriteLine("  TypeFinder /path/to/workspace Controller --file-types .cs,.ts");
+    return 1;
+}
+
+string workspacePath = args[0];
+string typeName = args[1];
+
+// Parse options
+var options = ParseOptions(args.Skip(2).ToArray());
+
+if (!Directory.Exists(workspacePath))
+{
+    Console.WriteLine($"Error: Workspace path '{workspacePath}' does not exist.");
+    return 1;
+}
+
+try
+{
+    var results = await FindTypeAsync(workspacePath, typeName, options);
+    
+    if (results.Count == 0)
     {
-        static async Task<int> Main(string[] args)
+        Console.WriteLine($"No types found matching '{typeName}' in workspace '{workspacePath}'");
+        return 0;
+    }
+
+    Console.WriteLine($"Found {results.Count} result(s) for type '{typeName}':");
+    Console.WriteLine();
+
+    foreach (var result in results.Take(options.MaxResults))
+    {
+        Console.WriteLine($"File: {result.FilePath}");
+        Console.WriteLine($"Line: {result.LineNumber}");
+        Console.WriteLine($"Type: {result.Type}");
+        Console.WriteLine($"Kind: {result.Kind}");
+        Console.WriteLine($"Context: {result.Context}");
+        Console.WriteLine();
+    }
+
+    if (results.Count > options.MaxResults)
+    {
+        Console.WriteLine($"... and {results.Count - options.MaxResults} more results (use --max-results to see more)");
+    }
+
+    return 0;
+}
+catch (Exception ex)
+{
+    Console.WriteLine($"Error: {ex.Message}");
+    return 1;
+}
+
+static SearchOptions ParseOptions(string[] args)
+{
+    var options = new SearchOptions();
+    
+    for (int i = 0; i < args.Length; i++)
+    {
+        switch (args[i].ToLower())
         {
-            if (args.Length < 2)
-            {
-                Console.WriteLine("Usage: TypeFinder <workspace-path> <type-name> [options]");
-                Console.WriteLine();
-                Console.WriteLine("Options:");
-                Console.WriteLine("  --exact-match    Search for exact type name match");
-                Console.WriteLine("  --case-sensitive Use case-sensitive search");
-                Console.WriteLine("  --file-types     Comma-separated list of file extensions to search (default: .cs,.ts,.js,.py,.java,.go,.rs,.php)");
-                Console.WriteLine("  --max-results    Maximum number of results to return (default: 50)");
-                Console.WriteLine("  --include-references Include type references (not just definitions)");
-                Console.WriteLine();
-                Console.WriteLine("Examples:");
-                Console.WriteLine("  TypeFinder /path/to/workspace User");
-                Console.WriteLine("  TypeFinder /path/to/workspace \"MyClass\" --exact-match");
-                Console.WriteLine("  TypeFinder /path/to/workspace Controller --file-types .cs,.ts");
-                return 1;
-            }
+            case "--exact-match":
+                options.ExactMatch = true;
+                break;
+            case "--case-sensitive":
+                options.CaseSensitive = true;
+                break;
+            case "--file-types":
+                if (i + 1 < args.Length)
+                {
+                    options.FileTypes = args[++i].Split(',', StringSplitOptions.RemoveEmptyEntries);
+                }
+                break;
+            case "--max-results":
+                if (i + 1 < args.Length && int.TryParse(args[++i], out int maxResults))
+                {
+                    options.MaxResults = maxResults;
+                }
+                break;
+            case "--include-references":
+                options.IncludeReferences = true;
+                break;
+        }
+    }
 
-            string workspacePath = args[0];
-            string typeName = args[1];
+    return options;
+}
 
-            // Parse options
-            var options = ParseOptions(args.Skip(2).ToArray());
+static async Task<List<TypeResult>> FindTypeAsync(string workspacePath, string typeName, SearchOptions options)
+{
+    var results = new List<TypeResult>();
 
-            if (!Directory.Exists(workspacePath))
-            {
-                Console.WriteLine($"Error: Workspace path '{workspacePath}' does not exist.");
-                return 1;
-            }
-
+    // Try to find solution files first
+    var solutionFiles = Directory.GetFiles(workspacePath, "*.sln", SearchOption.AllDirectories);
+    
+    if (solutionFiles.Length > 0)
+    {
+        foreach (var solutionFile in solutionFiles)
+        {
             try
             {
-                var results = await FindTypeAsync(workspacePath, typeName, options);
-                
-                if (results.Count == 0)
-                {
-                    Console.WriteLine($"No types found matching '{typeName}' in workspace '{workspacePath}'");
-                    return 0;
-                }
-
-                Console.WriteLine($"Found {results.Count} result(s) for type '{typeName}':");
-                Console.WriteLine();
-
-                foreach (var result in results.Take(options.MaxResults))
-                {
-                    Console.WriteLine($"File: {result.FilePath}");
-                    Console.WriteLine($"Line: {result.LineNumber}");
-                    Console.WriteLine($"Type: {result.Type}");
-                    Console.WriteLine($"Kind: {result.Kind}");
-                    Console.WriteLine($"Context: {result.Context}");
-                    Console.WriteLine();
-                }
-
-                if (results.Count > options.MaxResults)
-                {
-                    Console.WriteLine($"... and {results.Count - options.MaxResults} more results (use --max-results to see more)");
-                }
-
-                return 0;
+                var solutionResults = await SearchSolutionAsync(solutionFile, typeName, options);
+                results.AddRange(solutionResults);
             }
             catch (Exception ex)
             {
-                Console.WriteLine($"Error: {ex.Message}");
-                return 1;
+                Console.WriteLine($"Warning: Could not process solution {solutionFile}: {ex.Message}");
             }
         }
+    }
 
-        static SearchOptions ParseOptions(string[] args)
-        {
-            var options = new SearchOptions();
-            
-            for (int i = 0; i < args.Length; i++)
-            {
-                switch (args[i].ToLower())
-                {
-                    case "--exact-match":
-                        options.ExactMatch = true;
-                        break;
-                    case "--case-sensitive":
-                        options.CaseSensitive = true;
-                        break;
-                    case "--file-types":
-                        if (i + 1 < args.Length)
-                        {
-                            options.FileTypes = args[++i].Split(',', StringSplitOptions.RemoveEmptyEntries);
-                        }
-                        break;
-                    case "--max-results":
-                        if (i + 1 < args.Length && int.TryParse(args[++i], out int maxResults))
-                        {
-                            options.MaxResults = maxResults;
-                        }
-                        break;
-                    case "--include-references":
-                        options.IncludeReferences = true;
-                        break;
-                }
-            }
-
-            return options;
-        }
-
-        static async Task<List<TypeResult>> FindTypeAsync(string workspacePath, string typeName, SearchOptions options)
-        {
-            var results = new List<TypeResult>();
-
-            // Try to find solution files first
-            var solutionFiles = Directory.GetFiles(workspacePath, "*.sln", SearchOption.AllDirectories);
-            
-            if (solutionFiles.Length > 0)
-            {
-                foreach (var solutionFile in solutionFiles)
-                {
-                    try
-                    {
-                        var solutionResults = await SearchSolutionAsync(solutionFile, typeName, options);
-                        results.AddRange(solutionResults);
-                    }
-                    catch (Exception ex)
-                    {
-                        Console.WriteLine($"Warning: Could not process solution {solutionFile}: {ex.Message}");
-                    }
-                }
-            }
-
-            // If no solution files or no results, try project files
-            if (results.Count == 0)
-            {
-                var projectFiles = Directory.GetFiles(workspacePath, "*.csproj", SearchOption.AllDirectories);
-                
-                foreach (var projectFile in projectFiles)
-                {
-                    try
-                    {
-                        var projectResults = await SearchProjectAsync(projectFile, typeName, options);
-                        results.AddRange(projectResults);
-                    }
-                    catch (Exception ex)
-                    {
-                        Console.WriteLine($"Warning: Could not process project {projectFile}: {ex.Message}");
-                    }
-                }
-            }
-
-            // If still no results, fall back to file-based search
-            if (results.Count == 0)
-            {
-                var fileResults = await SearchFilesAsync(workspacePath, typeName, options);
-                results.AddRange(fileResults);
-            }
-
-            return results;
-        }
-
-        static async Task<List<TypeResult>> SearchSolutionAsync(string solutionPath, string typeName, SearchOptions options)
-        {
-            var results = new List<TypeResult>();
-            
-            using var workspace = MSBuildWorkspace.Create();
-            var solution = await workspace.OpenSolutionAsync(solutionPath);
-
-            foreach (var project in solution.Projects)
-            {
-                try
-                {
-                    var projectResults = await SearchProjectSymbolsAsync(project, typeName, options);
-                    results.AddRange(projectResults);
-                }
-                catch (Exception ex)
-                {
-                    Console.WriteLine($"Warning: Could not process project {project.Name}: {ex.Message}");
-                }
-            }
-
-            return results;
-        }
-
-        static async Task<List<TypeResult>> SearchProjectAsync(string projectPath, string typeName, SearchOptions options)
-        {
-            using var workspace = MSBuildWorkspace.Create();
-            var project = await workspace.OpenProjectAsync(projectPath);
-            return await SearchProjectSymbolsAsync(project, typeName, options);
-        }
-
-        static async Task<List<TypeResult>> SearchProjectSymbolsAsync(Project project, string typeName, SearchOptions options)
-        {
-            var results = new List<TypeResult>();
-            var compilation = await project.GetCompilationAsync();
-            
-            if (compilation == null) return results;
-
-            // Search for type symbols
-            var symbols = new List<ISymbol>();
-
-            // Search in global namespace
-            var globalNamespace = compilation.GlobalNamespace;
-            symbols.AddRange(FindSymbolsInNamespace(globalNamespace, typeName, options));
-
-            // Search in all namespaces
-            foreach (var namespaceSymbol in GetAllNamespaces(globalNamespace))
-            {
-                symbols.AddRange(FindSymbolsInNamespace(namespaceSymbol, typeName, options));
-            }
-
-            foreach (var symbol in symbols)
-            {
-                var locations = symbol.Locations;
-                foreach (var location in locations)
-                {
-                    if (location.IsInSource)
-                    {
-                        var result = await CreateTypeResultAsync(location, symbol, project, options);
-                        if (result != null)
-                        {
-                            results.Add(result);
-                        }
-                    }
-                }
-
-                // If including references, also find all references to this symbol
-                if (options.IncludeReferences)
-                {
-                    var references = await SymbolFinder.FindReferencesAsync(symbol, project.Solution);
-                    foreach (var reference in references)
-                    {
-                        foreach (var location in reference.Locations)
-                        {
-                            var result = await CreateTypeResultAsync(location.Location, symbol, project, options);
-                            if (result != null)
-                            {
-                                result.Kind = "reference";
-                                results.Add(result);
-                            }
-                        }
-                    }
-                }
-            }
-
-            return results;
-        }
-
-        static IEnumerable<ISymbol> FindSymbolsInNamespace(INamespaceSymbol namespaceSymbol, string typeName, SearchOptions options)
-        {
-            var symbols = new List<ISymbol>();
-
-            // Search for types in this namespace
-            foreach (var type in namespaceSymbol.GetTypeMembers())
-            {
-                if (MatchesTypeName(type.Name, typeName, options))
-                {
-                    symbols.Add(type);
-                }
-            }
-
-            // Search in nested namespaces
-            foreach (var nestedNamespace in namespaceSymbol.GetNamespaceMembers())
-            {
-                symbols.AddRange(FindSymbolsInNamespace(nestedNamespace, typeName, options));
-            }
-
-            return symbols;
-        }
-
-        static IEnumerable<INamespaceSymbol> GetAllNamespaces(INamespaceSymbol namespaceSymbol)
-        {
-            var namespaces = new List<INamespaceSymbol>();
-            
-            foreach (var member in namespaceSymbol.GetMembers())
-            {
-                if (member is INamespaceSymbol nestedNamespace)
-                {
-                    namespaces.Add(nestedNamespace);
-                    namespaces.AddRange(GetAllNamespaces(nestedNamespace));
-                }
-            }
-
-            return namespaces;
-        }
-
-        static bool MatchesTypeName(string symbolName, string searchName, SearchOptions options)
-        {
-            if (options.ExactMatch)
-            {
-                return options.CaseSensitive 
-                    ? symbolName == searchName 
-                    : string.Equals(symbolName, searchName, StringComparison.OrdinalIgnoreCase);
-            }
-            else
-            {
-                return options.CaseSensitive 
-                    ? symbolName.Contains(searchName) 
-                    : symbolName.IndexOf(searchName, StringComparison.OrdinalIgnoreCase) >= 0;
-            }
-        }
-
-        static async Task<TypeResult?> CreateTypeResultAsync(Location location, ISymbol symbol, Project project, SearchOptions options)
-        {
-            if (!location.IsInSource) return null;
-
-            var sourceText = await location.SourceTree!.GetTextAsync();
-            var lineSpan = sourceText.Lines.GetLinePositionSpan(location.SourceSpan);
-            
-            var context = GetContext(sourceText, lineSpan.Start.Line, options);
-            var typeKind = GetTypeKind(symbol);
-
-            return new TypeResult
-            {
-                FilePath = location.SourceTree!.FilePath,
-                LineNumber = lineSpan.Start.Line + 1,
-                Type = symbol.Name,
-                Kind = typeKind,
-                Context = context
-            };
-        }
-
-        static string GetContext(SourceText sourceText, int lineNumber, SearchOptions options)
-        {
-            var lines = sourceText.Lines;
-            var start = Math.Max(0, lineNumber - 2);
-            var end = Math.Min(lines.Count - 1, lineNumber + 2);
-            
-            var contextLines = new List<string>();
-            for (int i = start; i <= end; i++)
-            {
-                var line = lines[i].ToString();
-                var prefix = i == lineNumber ? ">>> " : "    ";
-                contextLines.Add($"{prefix}{line}");
-            }
-            
-            return string.Join(Environment.NewLine, contextLines);
-        }
-
-        static string GetTypeKind(ISymbol symbol)
-        {
-            return symbol switch
-            {
-                ITypeSymbol typeSymbol => typeSymbol.TypeKind.ToString().ToLower(),
-                INamespaceSymbol => "namespace",
-                IMethodSymbol => "method",
-                IPropertySymbol => "property",
-                IFieldSymbol => "field",
-                IEventSymbol => "event",
-                _ => "symbol"
-            };
-        }
-
-        static async Task<List<TypeResult>> SearchFilesAsync(string workspacePath, string typeName, SearchOptions options)
-        {
-            var results = new List<TypeResult>();
-            var fileExtensions = options.FileTypes ?? new[] { ".cs", ".ts", ".js", ".py", ".java", ".go", ".rs", ".php" };
-
-            foreach (var file in GetFilesRecursively(workspacePath, fileExtensions))
-            {
-                try
-                {
-                    var fileResults = await SearchFileAsync(file, typeName, options);
-                    results.AddRange(fileResults);
-                }
-                catch (Exception ex)
-                {
-                    Console.WriteLine($"Warning: Could not search file {file}: {ex.Message}");
-                }
-            }
-
-            return results;
-        }
-
-        static IEnumerable<string> GetFilesRecursively(string directory, string[] extensions)
+    // If no solution files or no results, try project files
+    if (results.Count == 0)
+    {
+        var projectFiles = Directory.GetFiles(workspacePath, "*.csproj", SearchOption.AllDirectories);
+        
+        foreach (var projectFile in projectFiles)
         {
             try
             {
-                return Directory.GetFiles(directory, "*.*", SearchOption.AllDirectories)
-                    .Where(file => extensions.Any(ext => file.EndsWith(ext, StringComparison.OrdinalIgnoreCase)));
+                var projectResults = await SearchProjectAsync(projectFile, typeName, options);
+                results.AddRange(projectResults);
             }
-            catch (UnauthorizedAccessException)
+            catch (Exception ex)
             {
-                return Enumerable.Empty<string>();
+                Console.WriteLine($"Warning: Could not process project {projectFile}: {ex.Message}");
+            }
+        }
+    }
+
+    // If still no results, fall back to file-based search
+    if (results.Count == 0)
+    {
+        var fileResults = await SearchFilesAsync(workspacePath, typeName, options);
+        results.AddRange(fileResults);
+    }
+
+    return results;
+}
+
+static async Task<List<TypeResult>> SearchSolutionAsync(string solutionPath, string typeName, SearchOptions options)
+{
+    var results = new List<TypeResult>();
+    
+    using var workspace = MSBuildWorkspace.Create();
+    var solution = await workspace.OpenSolutionAsync(solutionPath);
+
+    foreach (var project in solution.Projects)
+    {
+        try
+        {
+            var projectResults = await SearchProjectSymbolsAsync(project, typeName, options);
+            results.AddRange(projectResults);
+        }
+        catch (Exception ex)
+        {
+            Console.WriteLine($"Warning: Could not process project {project.Name}: {ex.Message}");
+        }
+    }
+
+    return results;
+}
+
+static async Task<List<TypeResult>> SearchProjectAsync(string projectPath, string typeName, SearchOptions options)
+{
+    using var workspace = MSBuildWorkspace.Create();
+    var project = await workspace.OpenProjectAsync(projectPath);
+    return await SearchProjectSymbolsAsync(project, typeName, options);
+}
+
+static async Task<List<TypeResult>> SearchProjectSymbolsAsync(Project project, string typeName, SearchOptions options)
+{
+    var results = new List<TypeResult>();
+    var compilation = await project.GetCompilationAsync();
+    
+    if (compilation == null) return results;
+
+    // Search for type symbols
+    var symbols = new List<ISymbol>();
+
+    // Search in global namespace
+    var globalNamespace = compilation.GlobalNamespace;
+    symbols.AddRange(FindSymbolsInNamespace(globalNamespace, typeName, options));
+
+    // Search in all namespaces
+    foreach (var namespaceSymbol in GetAllNamespaces(globalNamespace))
+    {
+        symbols.AddRange(FindSymbolsInNamespace(namespaceSymbol, typeName, options));
+    }
+
+    foreach (var symbol in symbols)
+    {
+        var locations = symbol.Locations;
+        foreach (var location in locations)
+        {
+            if (location.IsInSource)
+            {
+                var result = await CreateTypeResultAsync(location, symbol, project, options);
+                if (result != null)
+                {
+                    results.Add(result);
+                }
             }
         }
 
-        static async Task<List<TypeResult>> SearchFileAsync(string filePath, string typeName, SearchOptions options)
+        // If including references, also find all references to this symbol
+        if (options.IncludeReferences)
         {
-            var results = new List<TypeResult>();
-            var lines = await File.ReadAllLinesAsync(filePath);
-            var comparison = options.CaseSensitive ? StringComparison.Ordinal : StringComparison.OrdinalIgnoreCase;
-
-            for (int i = 0; i < lines.Length; i++)
+            var references = await SymbolFinder.FindReferencesAsync(symbol, project.Solution);
+            foreach (var reference in references)
             {
-                var line = lines[i];
-                var lineNumber = i + 1;
-
-                if (options.ExactMatch)
+                foreach (var location in reference.Locations)
                 {
-                    if (IsTypeDefinition(line, typeName, comparison))
+                    var result = await CreateTypeResultAsync(location.Location, symbol, project, options);
+                    if (result != null)
                     {
-                        results.Add(new TypeResult
-                        {
-                            FilePath = filePath,
-                            LineNumber = lineNumber,
-                            Context = GetContext(lines, i),
-                            Type = typeName,
-                            Kind = DetermineTypeFromLine(line)
-                        });
+                        result.Kind = "reference";
+                        results.Add(result);
                     }
                 }
-                else
+            }
+        }
+    }
+
+    return results;
+}
+
+static IEnumerable<ISymbol> FindSymbolsInNamespace(INamespaceSymbol namespaceSymbol, string typeName, SearchOptions options)
+{
+    var symbols = new List<ISymbol>();
+
+    // Search for types in this namespace
+    foreach (var type in namespaceSymbol.GetTypeMembers())
+    {
+        if (MatchesTypeName(type.Name, typeName, options))
+        {
+            symbols.Add(type);
+        }
+    }
+
+    // Search in nested namespaces
+    foreach (var nestedNamespace in namespaceSymbol.GetNamespaceMembers())
+    {
+        symbols.AddRange(FindSymbolsInNamespace(nestedNamespace, typeName, options));
+    }
+
+    return symbols;
+}
+
+static IEnumerable<INamespaceSymbol> GetAllNamespaces(INamespaceSymbol namespaceSymbol)
+{
+    var namespaces = new List<INamespaceSymbol>();
+    
+    foreach (var member in namespaceSymbol.GetMembers())
+    {
+        if (member is INamespaceSymbol nestedNamespace)
+        {
+            namespaces.Add(nestedNamespace);
+            namespaces.AddRange(GetAllNamespaces(nestedNamespace));
+        }
+    }
+
+    return namespaces;
+}
+
+static bool MatchesTypeName(string symbolName, string searchName, SearchOptions options)
+{
+    if (options.ExactMatch)
+    {
+        return options.CaseSensitive 
+            ? symbolName == searchName 
+            : string.Equals(symbolName, searchName, StringComparison.OrdinalIgnoreCase);
+    }
+    else
+    {
+        return options.CaseSensitive 
+            ? symbolName.Contains(searchName) 
+            : symbolName.IndexOf(searchName, StringComparison.OrdinalIgnoreCase) >= 0;
+    }
+}
+
+static async Task<TypeResult?> CreateTypeResultAsync(Location location, ISymbol symbol, Project project, SearchOptions options)
+{
+    if (!location.IsInSource) return null;
+
+    var sourceText = await location.SourceTree!.GetTextAsync();
+    var lineSpan = sourceText.Lines.GetLinePositionSpan(location.SourceSpan);
+    
+    var context = GetContextFromSourceText(sourceText, lineSpan.Start.Line);
+    var typeKind = GetTypeKind(symbol);
+
+    return new TypeResult
+    {
+        FilePath = location.SourceTree!.FilePath,
+        LineNumber = lineSpan.Start.Line + 1,
+        Type = symbol.Name,
+        Kind = typeKind,
+        Context = context
+    };
+}
+
+static string GetContextFromSourceText(SourceText sourceText, int lineNumber)
+{
+    var lines = sourceText.Lines;
+    var start = Math.Max(0, lineNumber - 2);
+    var end = Math.Min(lines.Count - 1, lineNumber + 2);
+    
+    var contextLines = new List<string>();
+    for (int i = start; i <= end; i++)
+    {
+        var line = lines[i].ToString();
+        var prefix = i == lineNumber ? ">>> " : "    ";
+        contextLines.Add($"{prefix}{line}");
+    }
+    
+    return string.Join(Environment.NewLine, contextLines);
+}
+
+static string GetTypeKind(ISymbol symbol)
+{
+    return symbol switch
+    {
+        ITypeSymbol typeSymbol => typeSymbol.TypeKind.ToString().ToLower(),
+        INamespaceSymbol => "namespace",
+        IMethodSymbol => "method",
+        IPropertySymbol => "property",
+        IFieldSymbol => "field",
+        IEventSymbol => "event",
+        _ => "symbol"
+    };
+}
+
+static async Task<List<TypeResult>> SearchFilesAsync(string workspacePath, string typeName, SearchOptions options)
+{
+    var results = new List<TypeResult>();
+    var fileExtensions = options.FileTypes ?? new[] { ".cs", ".ts", ".js", ".py", ".java", ".go", ".rs", ".php" };
+
+    foreach (var file in GetFilesRecursively(workspacePath, fileExtensions))
+    {
+        try
+        {
+            var fileResults = await SearchFileAsync(file, typeName, options);
+            results.AddRange(fileResults);
+        }
+        catch (Exception ex)
+        {
+            Console.WriteLine($"Warning: Could not search file {file}: {ex.Message}");
+        }
+    }
+
+    return results;
+}
+
+static IEnumerable<string> GetFilesRecursively(string directory, string[] extensions)
+{
+    try
+    {
+        return Directory.GetFiles(directory, "*.*", SearchOption.AllDirectories)
+            .Where(file => extensions.Any(ext => file.EndsWith(ext, StringComparison.OrdinalIgnoreCase)));
+    }
+    catch (UnauthorizedAccessException)
+    {
+        return Enumerable.Empty<string>();
+    }
+}
+
+static async Task<List<TypeResult>> SearchFileAsync(string filePath, string typeName, SearchOptions options)
+{
+    var results = new List<TypeResult>();
+    var lines = await File.ReadAllLinesAsync(filePath);
+    var comparison = options.CaseSensitive ? StringComparison.Ordinal : StringComparison.OrdinalIgnoreCase;
+
+    for (int i = 0; i < lines.Length; i++)
+    {
+        var line = lines[i];
+        var lineNumber = i + 1;
+
+        if (options.ExactMatch)
+        {
+            if (IsTypeDefinition(line, typeName, comparison))
+            {
+                results.Add(new TypeResult
                 {
-                    if (line.IndexOf(typeName, comparison) >= 0)
-                    {
-                        results.Add(new TypeResult
-                        {
-                            FilePath = filePath,
-                            LineNumber = lineNumber,
-                            Context = GetContext(lines, i),
-                            Type = typeName,
-                            Kind = DetermineTypeFromLine(line)
-                        });
-                    }
-                }
+                    FilePath = filePath,
+                    LineNumber = lineNumber,
+                    Context = GetContextFromLines(lines, i),
+                    Type = typeName,
+                    Kind = DetermineTypeFromLine(line)
+                });
             }
-
-            return results;
         }
-
-        static bool IsTypeDefinition(string line, string typeName, StringComparison comparison)
+        else
         {
-            var patterns = new[]
+            if (line.IndexOf(typeName, comparison) >= 0)
             {
-                $@"\b(class|interface|struct|enum|record)\s+{Regex.Escape(typeName)}\b",
-                $@"\b(type|typedef)\s+{Regex.Escape(typeName)}\b",
-                $@"\b{Regex.Escape(typeName)}\s*[:=]",
-                $@"\b{Regex.Escape(typeName)}\s*\(",
-                $@"\b{Regex.Escape(typeName)}\s*<",
-                $@"\b{Regex.Escape(typeName)}\s*\["
-            };
-
-            return patterns.Any(pattern => Regex.IsMatch(line, pattern, RegexOptions.IgnoreCase));
-        }
-
-        static string GetContext(string[] lines, int lineIndex)
-        {
-            var start = Math.Max(0, lineIndex - 2);
-            var end = Math.Min(lines.Length - 1, lineIndex + 2);
-            
-            var contextLines = new List<string>();
-            for (int i = start; i <= end; i++)
-            {
-                var prefix = i == lineIndex ? ">>> " : "    ";
-                contextLines.Add($"{prefix}{lines[i]}");
+                results.Add(new TypeResult
+                {
+                    FilePath = filePath,
+                    LineNumber = lineNumber,
+                    Context = GetContextFromLines(lines, i),
+                    Type = typeName,
+                    Kind = DetermineTypeFromLine(line)
+                });
             }
-            
-            return string.Join(Environment.NewLine, contextLines);
-        }
-
-        static string DetermineTypeFromLine(string line)
-        {
-            if (line.Contains("class ")) return "class";
-            if (line.Contains("interface ")) return "interface";
-            if (line.Contains("struct ")) return "struct";
-            if (line.Contains("enum ")) return "enum";
-            if (line.Contains("record ")) return "record";
-            if (line.Contains("type ")) return "type";
-            if (line.Contains("typedef ")) return "typedef";
-            if (line.Contains("function ")) return "function";
-            if (line.Contains("def ")) return "function";
-            if (line.Contains("func ")) return "function";
-            return "reference";
         }
     }
 
-    class SearchOptions
-    {
-        public bool ExactMatch { get; set; } = false;
-        public bool CaseSensitive { get; set; } = false;
-        public string[]? FileTypes { get; set; } = null;
-        public int MaxResults { get; set; } = 50;
-        public bool IncludeReferences { get; set; } = false;
-    }
+    return results;
+}
 
-    class TypeResult
+static bool IsTypeDefinition(string line, string typeName, StringComparison comparison)
+{
+    var patterns = new[]
     {
-        public string FilePath { get; set; } = "";
-        public int LineNumber { get; set; }
-        public string Type { get; set; } = "";
-        public string Kind { get; set; } = "";
-        public string Context { get; set; } = "";
+        $@"\b(class|interface|struct|enum|record)\s+{Regex.Escape(typeName)}\b",
+        $@"\b(type|typedef)\s+{Regex.Escape(typeName)}\b",
+        $@"\b{Regex.Escape(typeName)}\s*[:=]",
+        $@"\b{Regex.Escape(typeName)}\s*\(",
+        $@"\b{Regex.Escape(typeName)}\s*<",
+        $@"\b{Regex.Escape(typeName)}\s*\["
+    };
+
+    return patterns.Any(pattern => Regex.IsMatch(line, pattern, RegexOptions.IgnoreCase));
+}
+
+static string GetContextFromLines(string[] lines, int lineIndex)
+{
+    var start = Math.Max(0, lineIndex - 2);
+    var end = Math.Min(lines.Length - 1, lineIndex + 2);
+    
+    var contextLines = new List<string>();
+    for (int i = start; i <= end; i++)
+    {
+        var prefix = i == lineIndex ? ">>> " : "    ";
+        contextLines.Add($"{prefix}{lines[i]}");
     }
+    
+    return string.Join(Environment.NewLine, contextLines);
+}
+
+static string DetermineTypeFromLine(string line)
+{
+    if (line.Contains("class ")) return "class";
+    if (line.Contains("interface ")) return "interface";
+    if (line.Contains("struct ")) return "struct";
+    if (line.Contains("enum ")) return "enum";
+    if (line.Contains("record ")) return "record";
+    if (line.Contains("type ")) return "type";
+    if (line.Contains("typedef ")) return "typedef";
+    if (line.Contains("function ")) return "function";
+    if (line.Contains("def ")) return "function";
+    if (line.Contains("func ")) return "function";
+    return "reference";
+}
+
+class SearchOptions
+{
+    public bool ExactMatch { get; set; } = false;
+    public bool CaseSensitive { get; set; } = false;
+    public string[]? FileTypes { get; set; } = null;
+    public int MaxResults { get; set; } = 50;
+    public bool IncludeReferences { get; set; } = false;
+}
+
+class TypeResult
+{
+    public string FilePath { get; set; } = "";
+    public int LineNumber { get; set; }
+    public string Type { get; set; } = "";
+    public string Kind { get; set; } = "";
+    public string Context { get; set; } = "";
 }

--- a/src/TypeFinder/Program.cs
+++ b/src/TypeFinder/Program.cs
@@ -1,0 +1,248 @@
+using System;
+using System.IO;
+using System.Text.RegularExpressions;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace TypeFinder
+{
+    class Program
+    {
+        static void Main(string[] args)
+        {
+            if (args.Length < 2)
+            {
+                Console.WriteLine("Usage: TypeFinder <workspace-path> <type-name> [options]");
+                Console.WriteLine();
+                Console.WriteLine("Options:");
+                Console.WriteLine("  --exact-match    Search for exact type name match");
+                Console.WriteLine("  --case-sensitive Use case-sensitive search");
+                Console.WriteLine("  --file-types     Comma-separated list of file extensions to search (default: .cs,.ts,.js,.py,.java,.go,.rs,.php)");
+                Console.WriteLine("  --max-results    Maximum number of results to return (default: 50)");
+                Console.WriteLine();
+                Console.WriteLine("Examples:");
+                Console.WriteLine("  TypeFinder /path/to/workspace User");
+                Console.WriteLine("  TypeFinder /path/to/workspace \"MyClass\" --exact-match");
+                Console.WriteLine("  TypeFinder /path/to/workspace Controller --file-types .cs,.ts");
+                return;
+            }
+
+            string workspacePath = args[0];
+            string typeName = args[1];
+
+            // Parse options
+            var options = ParseOptions(args.Skip(2).ToArray());
+
+            if (!Directory.Exists(workspacePath))
+            {
+                Console.WriteLine($"Error: Workspace path '{workspacePath}' does not exist.");
+                Environment.Exit(1);
+            }
+
+            try
+            {
+                var results = FindType(workspacePath, typeName, options);
+                
+                if (results.Count == 0)
+                {
+                    Console.WriteLine($"No types found matching '{typeName}' in workspace '{workspacePath}'");
+                    return;
+                }
+
+                Console.WriteLine($"Found {results.Count} result(s) for type '{typeName}':");
+                Console.WriteLine();
+
+                foreach (var result in results.Take(options.MaxResults))
+                {
+                    Console.WriteLine($"File: {result.FilePath}");
+                    Console.WriteLine($"Line: {result.LineNumber}");
+                    Console.WriteLine($"Context: {result.Context}");
+                    Console.WriteLine($"Type: {result.Type}");
+                    Console.WriteLine();
+                }
+
+                if (results.Count > options.MaxResults)
+                {
+                    Console.WriteLine($"... and {results.Count - options.MaxResults} more results (use --max-results to see more)");
+                }
+            }
+            catch (Exception ex)
+            {
+                Console.WriteLine($"Error: {ex.Message}");
+                Environment.Exit(1);
+            }
+        }
+
+        static SearchOptions ParseOptions(string[] args)
+        {
+            var options = new SearchOptions();
+            
+            for (int i = 0; i < args.Length; i++)
+            {
+                switch (args[i].ToLower())
+                {
+                    case "--exact-match":
+                        options.ExactMatch = true;
+                        break;
+                    case "--case-sensitive":
+                        options.CaseSensitive = true;
+                        break;
+                    case "--file-types":
+                        if (i + 1 < args.Length)
+                        {
+                            options.FileTypes = args[++i].Split(',', StringSplitOptions.RemoveEmptyEntries);
+                        }
+                        break;
+                    case "--max-results":
+                        if (i + 1 < args.Length && int.TryParse(args[++i], out int maxResults))
+                        {
+                            options.MaxResults = maxResults;
+                        }
+                        break;
+                }
+            }
+
+            return options;
+        }
+
+        static List<TypeResult> FindType(string workspacePath, string typeName, SearchOptions options)
+        {
+            var results = new List<TypeResult>();
+            var fileExtensions = options.FileTypes ?? new[] { ".cs", ".ts", ".js", ".py", ".java", ".go", ".rs", ".php" };
+
+            foreach (var file in GetFilesRecursively(workspacePath, fileExtensions))
+            {
+                try
+                {
+                    var fileResults = SearchFile(file, typeName, options);
+                    results.AddRange(fileResults);
+                }
+                catch (Exception ex)
+                {
+                    Console.WriteLine($"Warning: Could not search file {file}: {ex.Message}");
+                }
+            }
+
+            return results;
+        }
+
+        static IEnumerable<string> GetFilesRecursively(string directory, string[] extensions)
+        {
+            try
+            {
+                return Directory.GetFiles(directory, "*.*", SearchOption.AllDirectories)
+                    .Where(file => extensions.Any(ext => file.EndsWith(ext, StringComparison.OrdinalIgnoreCase)));
+            }
+            catch (UnauthorizedAccessException)
+            {
+                return Enumerable.Empty<string>();
+            }
+        }
+
+        static List<TypeResult> SearchFile(string filePath, string typeName, SearchOptions options)
+        {
+            var results = new List<TypeResult>();
+            var lines = File.ReadAllLines(filePath);
+            var comparison = options.CaseSensitive ? StringComparison.Ordinal : StringComparison.OrdinalIgnoreCase;
+
+            for (int i = 0; i < lines.Length; i++)
+            {
+                var line = lines[i];
+                var lineNumber = i + 1;
+
+                if (options.ExactMatch)
+                {
+                    // Look for exact type definitions
+                    if (IsTypeDefinition(line, typeName, comparison))
+                    {
+                        results.Add(new TypeResult
+                        {
+                            FilePath = filePath,
+                            LineNumber = lineNumber,
+                            Context = GetContext(lines, i),
+                            Type = DetermineTypeFromLine(line)
+                        });
+                    }
+                }
+                else
+                {
+                    // Look for type name mentions
+                    if (line.IndexOf(typeName, comparison) >= 0)
+                    {
+                        results.Add(new TypeResult
+                        {
+                            FilePath = filePath,
+                            LineNumber = lineNumber,
+                            Context = GetContext(lines, i),
+                            Type = DetermineTypeFromLine(line)
+                        });
+                    }
+                }
+            }
+
+            return results;
+        }
+
+        static bool IsTypeDefinition(string line, string typeName, StringComparison comparison)
+        {
+            // Common patterns for type definitions
+            var patterns = new[]
+            {
+                $@"\b(class|interface|struct|enum|record)\s+{Regex.Escape(typeName)}\b",
+                $@"\b(type|typedef)\s+{Regex.Escape(typeName)}\b",
+                $@"\b{Regex.Escape(typeName)}\s*[:=]",
+                $@"\b{Regex.Escape(typeName)}\s*\(",
+                $@"\b{Regex.Escape(typeName)}\s*<",
+                $@"\b{Regex.Escape(typeName)}\s*\["
+            };
+
+            return patterns.Any(pattern => Regex.IsMatch(line, pattern, RegexOptions.IgnoreCase));
+        }
+
+        static string GetContext(string[] lines, int lineIndex)
+        {
+            var start = Math.Max(0, lineIndex - 2);
+            var end = Math.Min(lines.Length - 1, lineIndex + 2);
+            
+            var contextLines = new List<string>();
+            for (int i = start; i <= end; i++)
+            {
+                var prefix = i == lineIndex ? ">>> " : "    ";
+                contextLines.Add($"{prefix}{lines[i]}");
+            }
+            
+            return string.Join(Environment.NewLine, contextLines);
+        }
+
+        static string DetermineTypeFromLine(string line)
+        {
+            if (line.Contains("class ")) return "class";
+            if (line.Contains("interface ")) return "interface";
+            if (line.Contains("struct ")) return "struct";
+            if (line.Contains("enum ")) return "enum";
+            if (line.Contains("record ")) return "record";
+            if (line.Contains("type ")) return "type";
+            if (line.Contains("typedef ")) return "typedef";
+            if (line.Contains("function ")) return "function";
+            if (line.Contains("def ")) return "function";
+            if (line.Contains("func ")) return "function";
+            return "reference";
+        }
+    }
+
+    class SearchOptions
+    {
+        public bool ExactMatch { get; set; } = false;
+        public bool CaseSensitive { get; set; } = false;
+        public string[]? FileTypes { get; set; } = null;
+        public int MaxResults { get; set; } = 50;
+    }
+
+    class TypeResult
+    {
+        public string FilePath { get; set; } = "";
+        public int LineNumber { get; set; }
+        public string Context { get; set; } = "";
+        public string Type { get; set; } = "";
+    }
+}

--- a/src/TypeFinder/TypeFinder.csproj
+++ b/src/TypeFinder/TypeFinder.csproj
@@ -1,0 +1,10 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+</Project>

--- a/src/TypeFinder/TypeFinder.csproj
+++ b/src/TypeFinder/TypeFinder.csproj
@@ -7,4 +7,8 @@
     <Nullable>enable</Nullable>
   </PropertyGroup>
 
+  <ItemGroup>
+    <PackageReference Include="Microsoft.CodeAnalysis.Workspaces.MSBuild" Version="4.14.0" />
+  </ItemGroup>
+
 </Project>


### PR DESCRIPTION
Refactor TypeFinder to use top-level statements and simplify publishing.

Modernize the C# code, streamline the installation process, and remove unnecessary Native AOT complexity from the project.

---

**Open Background Agent:** 

[Web](https://www.cursor.com/agents?id=bc-6c731b53-3b75-4bba-8f2f-0b023fc4c88b) · [Cursor](https://cursor.com/background-agent?bcId=bc-6c731b53-3b75-4bba-8f2f-0b023fc4c88b)

Refer to [Background Agent docs](https://docs.cursor.com/background-agents)